### PR TITLE
Richard's solution - Synchronize the text input with the displayed text

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="flex p-4 flex-col">
         <small class="text-xs text-gray-600">Text</small>
-        <input v-model="title" class="p-4 mt-2" :placeholder="'Enter Text'" />
+        <input v-model="title" class="p-4 mt-2" :placeholder="'Enter Text'" @input="handleInput" />
     </div>
 </template>
 
@@ -12,6 +12,9 @@ const editorStore = useEditorStore()
 
 const { title } = storeToRefs(editorStore)
 
+const handleInput = () => {
+  editorStore.updateTitle(title.value)
+}
 
 </script>
 

--- a/src/components/site.vue
+++ b/src/components/site.vue
@@ -5,13 +5,12 @@
 </template>
 
 <script lang='ts' setup>
-import { useEditorStore } from '../store/editor';
-import { storeToRefs } from 'pinia'
+import { useRoute } from "vue-router";
+import { computed } from "vue";
 
-const editorStore = useEditorStore()
+const route = useRoute()
 
-const { title } = storeToRefs(editorStore)
-
+const title = computed(() => route.query.title as string)
 </script>
 
 <style lang='postcss' scoped></style>

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -5,5 +5,11 @@ export const useEditorStore = defineStore('editor', {
         return {
             title: 'Hello'
         }
+    },
+
+    actions: {
+        updateTitle(title: string) {
+            this.title = title
+        }
     }
 })

--- a/src/views/site.vue
+++ b/src/views/site.vue
@@ -11,16 +11,35 @@
                   <small class="text-xs text-gray-600 leading-0 mt-1 ml-1">https://testsite.smartbloks.site</small>
                </div>
             </div>
-            <iframe class="w-full flex-1" src="/preview"></iframe>
+            <iframe class="w-full flex-1" :src="`/preview?title=${newTitle}`"></iframe>
          </div>
       </div>
    </div>
 </template>
 
 <script lang='ts' setup>
+import {ref, watch} from "vue";
+import { storeToRefs } from 'pinia'
+import { useEditorStore } from '../store/editor';
+
 import Sidebar from '../components/Sidebar.vue'
 
+const editorStore = useEditorStore()
 
+const { title } = storeToRefs(editorStore)
+const newTitle = ref<string>('')
+
+/**
+  flickering fix -
+  debounce the title so it doesn't reload the iframe on every input
+*/
+const debounceTitle = () => {
+   setTimeout(() => {
+    newTitle.value = title.value
+  }, 700)
+}
+
+watch(title, () => debounceTitle(), { immediate: true })
 </script>
 
 <style lang='postcss' scoped></style>


### PR DESCRIPTION
## Problem

- Synchronize the text input with the displayed text, such that anything written in the input will show up in preview section.

## My Solution
- Context: I maintained the flow of the initial application setup and made sure that the solution is less complex and is most optimal.

- Approach: Since the iframe is not directly reactive, I have taken the approach of passing the value of the text input as a route query instead, and on the preview page where the value is needed, it is being displayed right there as a computed property with the help of the route query parameter.

## Challenge

Issue: On the preview side, there was a constant flickering for every text change because it basically reloads on every input.

Fix: I decided to debounce the text update for 700ms to make sure that it doesn't update on the preview side on every keystroke, but waits a little bit before reflecting the update.