### PR TITLE
synchronise input and iframe using web message event and reactive loc…

### DIFF
--- a/src/components/site.vue
+++ b/src/components/site.vue
@@ -5,12 +5,27 @@
 </template>
 
 <script lang='ts' setup>
+import { onMounted, onBeforeUnmount } from "vue";
 import { useEditorStore } from '../store/editor';
 import { storeToRefs } from 'pinia'
+import { ParentToIframeMessage } from "../types"
 
 const editorStore = useEditorStore()
 
 const { title } = storeToRefs(editorStore)
+
+const updateContent = (event: MessageEvent<ParentToIframeMessage>) => {
+  const storageTitle = localStorage.getItem('preview')
+  title.value = storageTitle ? storageTitle : event.data.title;
+};
+
+onMounted(() => {
+    window.addEventListener("message", updateContent)
+})
+
+onBeforeUnmount(()=> {
+    window.removeEventListener("message", updateContent)
+})
 
 </script>
 

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -3,7 +3,7 @@ import { defineStore } from "pinia";
 export const useEditorStore = defineStore('editor', {
     state() {
         return {
-            title: 'Hello'
+            title: localStorage.getItem('preview') || 'Hello' // prevents iframe to always pre-render with Hello text
         }
     }
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+export interface ParentToIframeMessage {
+    title: string
+}

--- a/src/views/site.vue
+++ b/src/views/site.vue
@@ -11,15 +11,32 @@
                   <small class="text-xs text-gray-600 leading-0 mt-1 ml-1">https://testsite.smartbloks.site</small>
                </div>
             </div>
-            <iframe class="w-full flex-1" src="/preview"></iframe>
+            <iframe class="w-full flex-1" src="/preview" ref="iframeRef"></iframe>
          </div>
       </div>
    </div>
 </template>
 
 <script lang='ts' setup>
+import {ref, watch} from "vue"
 import Sidebar from '../components/Sidebar.vue'
+import { useEditorStore } from "../store/editor"
+import {ParentToIframeMessage} from "../types.ts";
 
+const editorStore = useEditorStore()
+
+const iframeRef = ref<HTMLIFrameElement | null>(null)
+
+function sendMessage(msg: ParentToIframeMessage){
+  if (iframeRef.value && iframeRef.value.contentWindow){
+    iframeRef.value.contentWindow.postMessage(msg, "*")
+  }
+}
+
+watch(() => editorStore.title, (newVal) => {
+   localStorage.setItem('preview', editorStore.title || "")
+   sendMessage({title: newVal})
+}, {immediate: true})
 
 </script>
 


### PR DESCRIPTION
MY APPROACH

- Upon forking the code, I initially thought using a srcDoc on the iframe was the one liner solution, not until I viewed the code.
-  I settled with using a reactive localstorage and vue.js lifecycle hooks to simulate a persistent pinia state for simplicity. (there are available pinia plugins for this).
-  I strong typed the  message events and Iframe element since this is very crucial when it comes to scaling multiple events and avoiding browser errors.
- I initialized the store using the data from the local storage to prevent the iframe to always pre-render using the data from its own pinia store instance. 

FURTHER IMPROVEMENTS

- Based on other requirements, this approach can be modified to initialize the iframe using exising data from database since there is a single source of truth usign the store.
- The reactivity (localstorage) can be controlled to fit desired need. like updating the localstorage only when the Site page unmounts.

